### PR TITLE
Set a minimum log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ...
 }
 ```
+
+set a minimum level to filter out noise:
+```
+SimpleLogger.minimumLevel = .info
+```

--- a/Sources/SimpleLogger/LogLevel.swift
+++ b/Sources/SimpleLogger/LogLevel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum LogLevel {
+public enum LogLevel: Int {
     case verbose
     case debug
     case info
@@ -20,5 +20,11 @@ public enum LogLevel {
         case .error:
             return "🛑 [ERROR]"
         }
+    }
+}
+
+extension LogLevel: Comparable {
+    public static func < (lhs: LogLevel, rhs:LogLevel) -> Bool {
+        return lhs.rawValue < rhs.rawValue
     }
 }

--- a/Sources/SimpleLogger/SimpleLogger.swift
+++ b/Sources/SimpleLogger/SimpleLogger.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public final class Log {
 
+    private static var minimumLevel: LogLevel = .verbose
+
     private static var timeStamp: String {
         ISO8601DateFormatter.string(
             from: Date(),
@@ -11,6 +13,9 @@ public final class Log {
     }
 
     private static func printLine(_ message: String, level: LogLevel = .debug, file: String = #file, function: String = #function) {
+        guard level >= minimumLevel else {
+            return
+        }
         print("\(timeStamp) \(level.emoji): \(message) at \(lastComponent(of: file)): \(function)")
     }
 

--- a/Tests/SimpleLoggerTests/SimpleLoggerTests.swift
+++ b/Tests/SimpleLoggerTests/SimpleLoggerTests.swift
@@ -2,11 +2,33 @@ import XCTest
 @testable import SimpleLogger
 
 final class SimpleLoggerTests: XCTestCase {
-    func testExample() {
-        // empty test
+
+    func testVerboseLessThanAllOtherLevels() {
+        XCTAssertTrue(LogLevel.verbose < LogLevel.debug)
+        XCTAssertTrue(LogLevel.verbose < LogLevel.info)
+        XCTAssertTrue(LogLevel.verbose < LogLevel.warn)
+        XCTAssertTrue(LogLevel.verbose < LogLevel.error)
+    }
+
+    func testDebugLessThanInfoWarnAndError() {
+        XCTAssertTrue(LogLevel.debug < LogLevel.info)
+        XCTAssertTrue(LogLevel.debug < LogLevel.warn)
+        XCTAssertTrue(LogLevel.debug < LogLevel.error)
+    }
+
+    func testInfoLessThanWarnAndError() {
+        XCTAssertTrue(LogLevel.info < LogLevel.warn)
+        XCTAssertTrue(LogLevel.info < LogLevel.error)
+    }
+
+    func testWarnLessThanError() {
+        XCTAssertTrue(LogLevel.warn < LogLevel.error)
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testVerboseLessThanAllOtherLevels", testVerboseLessThanAllOtherLevels),
+        ("testDebugLessThanInfoWarnAndError", testDebugLessThanInfoWarnAndError),
+        ("testInfoLessThanWarnAndError", testInfoLessThanWarnAndError),
+        ("testWarnLessThanError", testWarnLessThanError)
     ]
 }


### PR DESCRIPTION
Set a minimum log level for the logger to use, making it ignore lower log statements. E.g.:
```
SimpleLogger.minimumLevel = .info
```