### PR TITLE
Simplify api

### DIFF
--- a/Sources/SimpleLogger/Log.swift
+++ b/Sources/SimpleLogger/Log.swift
@@ -83,22 +83,28 @@ public final class Log {
     // MARK: - Private methods
 
     private static func log(_ message: String, level: LogLevel, includeInRelease: Bool, file: String = #file, function: String = #function) {
+        guard let message = getLogMessage(message, level: level, file: file, function: function) else {
+            return
+        }
+
         if includeInRelease {
-            printLine(message, level: level, file: file, function: function)
+            print(message)
             return
         }
 
         #if DEBUG
-        printLine(message, level: level, file: file, function: function)
+        print(message)
         #endif
     }
 
-    private static func printLine(_ message: String, level: LogLevel, file: String = #file, function: String = #function) {
+    internal static func getLogMessage(_ message: String, level: LogLevel, includeTimeStamp: Bool = true, file: String = #file, function: String = #function) -> String? {
         guard level >= minimumLevel else {
-            return
+            return nil
         }
+
+        let timeStampPrefix = includeTimeStamp ? "\(timeStamp) " : ""
         let locationSuffix = logFileAndFunction ? " at \(lastComponent(of: file)): \(function)" : ""
-        print("\(timeStamp) \(level.emojiDescription): \(message)\(locationSuffix)")
+        return "\(timeStampPrefix)\(level.emojiDescription): \(message)\(locationSuffix)"
     }
 
     private static func lastComponent(of file: String) -> String {

--- a/Sources/SimpleLogger/LogLevel.swift
+++ b/Sources/SimpleLogger/LogLevel.swift
@@ -27,7 +27,7 @@ public enum LogLevel: Int {
 }
 
 extension LogLevel: Comparable {
-    internal static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
         return lhs.rawValue < rhs.rawValue
     }
 }

--- a/Sources/SimpleLogger/LogLevel.swift
+++ b/Sources/SimpleLogger/LogLevel.swift
@@ -10,7 +10,7 @@ public enum LogLevel: Int {
     case warn
     case error
 
-    var emojiDescription: String {
+    internal var emojiDescription: String {
         switch self {
         case .verbose:
             return "💬 [VERBOSE]"
@@ -27,7 +27,7 @@ public enum LogLevel: Int {
 }
 
 extension LogLevel: Comparable {
-    public static func < (lhs: LogLevel, rhs:LogLevel) -> Bool {
+    internal static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
         return lhs.rawValue < rhs.rawValue
     }
 }

--- a/Sources/SimpleLogger/SimpleLogger.swift
+++ b/Sources/SimpleLogger/SimpleLogger.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public final class Log {
 
+    // MARK: - Public properties
+
     /**
      Set the minimum level of priority to log. This is `LogLevel.verbose` by default.
 
@@ -16,6 +18,8 @@ public final class Log {
      */
     public static var logFileAndFunction = false
 
+    // MARK: - Private properties
+
     private static var timeStamp: String {
         ISO8601DateFormatter.string(
             from: Date(),
@@ -24,7 +28,72 @@ public final class Log {
         )
     }
 
-    private static func printLine(_ message: String, level: LogLevel = .debug, file: String = #file, function: String = #function) {
+    // MARK: - Public methods
+
+    /**
+     Log a message at level `LogLevel.verbose`.
+
+     - parameter message: The message to record.
+     - parameter includeInRelease: `true` if you want this to be included in release builds.
+     */
+    public static func verbose(_ message: String, includeInRelease: Bool = false, file: String = #file, function: String = #function) {
+        log(message, level: .verbose, includeInRelease: includeInRelease, file: file, function: function)
+    }
+
+    /**
+     Log a message at level `LogLevel.debug`.
+
+     - parameter message: The message to record.
+     - parameter includeInRelease: `true` if you want this to be included in release builds.
+     */
+    public static func debug(_ message: String, includeInRelease: Bool = false, file: String = #file, function: String = #function) {
+        log(message, level: .debug, includeInRelease: includeInRelease, file: file, function: function)
+    }
+
+    /**
+     Log a message at level `LogLevel.info`.
+
+     - parameter message: The message to record.
+     - parameter includeInRelease: `true` if you want this to be included in release builds.
+     */
+    public static func info(_ message: String, includeInRelease: Bool = false, file: String = #file, function: String = #function) {
+        log(message, level: .info, includeInRelease: includeInRelease, file: file, function: function)
+    }
+
+    /**
+     Log a message at level `LogLevel.warn`.
+
+     - parameter message: The message to record.
+     - parameter includeInRelease: `true` if you want this to be included in release builds.
+     */
+    public static func warn(_ message: String, includeInRelease: Bool = false, file: String = #file, function: String = #function) {
+        log(message, level: .warn, includeInRelease: includeInRelease, file: file, function: function)
+    }
+
+    /**
+     Log a message at level `LogLevel.error`.
+
+     - parameter message: The message to record.
+     - parameter includeInRelease: `true` if you want this to be included in release builds.
+     */
+    public static func error(_ message: String, includeInRelease: Bool = false, file: String = #file, function: String = #function) {
+        log(message, level: .error, includeInRelease: includeInRelease, file: file, function: function)
+    }
+
+    // MARK: - Private methods
+
+    private static func log(_ message: String, level: LogLevel, includeInRelease: Bool, file: String = #file, function: String = #function) {
+        if includeInRelease {
+            printLine(message, level: level, file: file, function: function)
+            return
+        }
+
+        #if DEBUG
+        printLine(message, level: level, file: file, function: function)
+        #endif
+    }
+
+    private static func printLine(_ message: String, level: LogLevel, file: String = #file, function: String = #function) {
         guard level >= minimumLevel else {
             return
         }
@@ -34,31 +103,5 @@ public final class Log {
 
     private static func lastComponent(of file: String) -> String {
         URL(fileURLWithPath: file).deletingPathExtension().lastPathComponent
-    }
-
-    /**
-     Print a statement to the log.
-
-     This will only be printed if the app is debuggable. Use `releaseLog` to print a statement in release configuration.
-
-     - parameter message: The custom string to log.
-     - parameter level: The `LogLevel` at which to record the print statement.
-     */
-    public static func log(_ message: String, level: LogLevel = .debug, file: String = #file, function: String = #function) {
-        #if DEBUG
-        printLine(message, level: level, file: file, function: function)
-        #endif
-    }
-
-    /**
-     Print a statement to the log.
-
-     If you want to print a statement that's only recorded in debug mode, use `log` instead.
-
-     - parameter message: The custom string to log.
-     - parameter level: The `LogLevel` at which to record the print statement.
-     */
-    public static func releaseLog(_ message: String, level: LogLevel = .debug, file: String = #file, function: String = #function) {
-        printLine(message, level: level, file: file, function: function)
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 import SimpleLoggerTests
 
 var tests = [XCTestCaseEntry]()
-tests += SimpleLoggerTests.allTests()
+tests += LogTests.allTests()
+tests += LogLevelTests.allTests()
 XCTMain(tests)

--- a/Tests/SimpleLoggerTests/LogLevelTests.swift
+++ b/Tests/SimpleLoggerTests/LogLevelTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import SimpleLogger
 
-final class SimpleLoggerTests: XCTestCase {
+final class LogLevelTests: XCTestCase {
 
     func testVerboseLessThanAllOtherLevels() {
         XCTAssertTrue(LogLevel.verbose < LogLevel.debug)

--- a/Tests/SimpleLoggerTests/LogTests.swift
+++ b/Tests/SimpleLoggerTests/LogTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import SimpleLogger
+
+final class LogTests: XCTestCase {
+
+    static var allTests = [
+        ("test_getLogMessage_when_minimum_level_lower_than_log_level_return_nil", test_getLogMessage_when_minimum_level_lower_than_log_level_return_nil),
+        ("test_getLogMessage_when_minimum_level_same_as_log_level_return_message", test_getLogMessage_when_minimum_level_same_as_log_level_return_message),
+        ("test_getLogMessage_when_minimum_level_higher_than_log_level_return_message", test_getLogMessage_when_minimum_level_higher_than_log_level_return_message),
+        ("test_getLogMessage_when_logFileAndFunction_is_true_include_file_and_function_metadata", test_getLogMessage_when_logFileAndFunction_is_true_include_file_and_function_metadata)
+    ]
+
+    // MARK: - test minimumLevel
+
+    func test_getLogMessage_when_minimum_level_lower_than_log_level_return_nil() {
+        Log.minimumLevel = .info
+        Log.logFileAndFunction = false
+
+        let observedMessage = Log.getLogMessage("Test message", level: .debug)
+
+        let expectedMessage: String? = nil
+        XCTAssertEqual(expectedMessage, observedMessage)
+    }
+
+    func test_getLogMessage_when_minimum_level_same_as_log_level_return_message() {
+        Log.minimumLevel = .info
+        Log.logFileAndFunction = false
+
+        let observedMessage = Log.getLogMessage("Test message", level: .info, includeTimeStamp: false)
+
+        let expectedMessage = "ℹ️ [INFO]: Test message"
+        XCTAssertEqual(expectedMessage, observedMessage)
+    }
+
+    func test_getLogMessage_when_minimum_level_higher_than_log_level_return_message() {
+        Log.minimumLevel = .info
+        Log.logFileAndFunction = false
+
+        let observedMessage = Log.getLogMessage("Test message", level: .warn, includeTimeStamp: false)
+
+        let expectedMessage = "⚠️ [WARNING]: Test message"
+        XCTAssertEqual(expectedMessage, observedMessage)
+    }
+
+    // MARK: - test logFileAndFunction
+
+    func test_getLogMessage_when_logFileAndFunction_is_true_include_file_and_function_metadata() {
+        Log.minimumLevel = .debug
+        Log.logFileAndFunction = true
+
+        let observedMessage = Log.getLogMessage("Test message", level: .info, includeTimeStamp: false)
+
+        let expectedMessage = "ℹ️ [INFO]: Test message at LogTests: test_getLogMessage_when_logFileAndFunction_is_true_include_file_and_function_metadata()"
+        XCTAssertEqual(expectedMessage, observedMessage)
+    }
+}

--- a/Tests/SimpleLoggerTests/XCTestManifests.swift
+++ b/Tests/SimpleLoggerTests/XCTestManifests.swift
@@ -3,7 +3,8 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(SimpleLoggerTests.allTests),
+        testCase(LogTests.allTests),
+        testCase(LogLevelTests.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
Fixing issue: https://github.com/neilgmacy/SimpleLogging/issues/5

- Adds new `verbose`, `debug`, `info`, `warn`, and `error` functions in place of `log` function. This makes the API a lot cleaner at the call site.
- Renamed `SimpleLogging.swift` to `Log.swift` since that's the name of the class in the file.
- Added a bunch of logging tests to make sure `Log.minimumLevel` and `Log.logFileAndFunction` settings work as expected.